### PR TITLE
Add recipes for MCL and MTG

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -5,4 +5,4 @@ author=MatyasP
 version=10111
 
 depends=
-optional_depends=repainter
+optional_depends=repainter,xcompat,mcl_core,default

--- a/nameznik.lua
+++ b/nameznik.lua
@@ -1,4 +1,7 @@
 local S = core.get_translator("nameznik")
+has_xcompat = minetest.get_modpath("xcompat") ~= nil
+has_mcl_core = minetest.get_modpath("mcl_core") ~= nil
+has_default = minetest.get_modpath("default") ~= nil
 
 local nameznik__groups = {dig_immediate=2, not_blocking_trains=1}
 local nameznik__simplenodebox = {type = "fixed",fixed = {
@@ -36,7 +39,7 @@ local function get_palette(nname)
 		return "nameznik_palette2.png"
 	end
 	--safety
-	core.log("warning","Nameznik: cannot get palette choice for " .. nnname)
+	minetest.log("warning","Nameznik: cannot get palette choice for " .. nnname)
 	return "nameznik_palette1.png"
 end
 
@@ -52,19 +55,49 @@ local dye_red = "dye:red"
 local dye_white = "dye:white"
 local steel_ingot = "default:steel_ingot"
 local cobble = "default:cobble"
-local base_ingredient = "default:tin_ingot"
+local base_ingredient = "default:copper_ingot"
+if has_xcompat then
+	recipes_table = {
+	  _r05_ = xcompat.materials["gravel"],
+	  _r1_ = xcompat.materials["sand"],
+	  _r05h_ = xcompat.materials["sandstone"],
+	  _r1h_ = xcompat.materials["flint"]
+	}
+	dye_red = xcompat.materials["dye_red"]
+	dye_white = xcompat.materials["dye_white"]
+	steel_ingot = xcompat.materials["steel_ingot"]
+	cobble = xcompat.materials["cobble"]
+	base_ingredient = xcompat.materials["copper_ingot"]
+elseif has_mcl_core then
+	recipes_table = {
+	  _r05_ = "mcl_core:gravel",
+	  _r1_ = "mcl_core:sand",
+	  _r05h_ = "mcl_core:sandstone",
+	  _r1h_ = "mcl_core:flint"
+	}
+	dye_red = "mcl_colorblocks:concrete_red"
+	dye_white = "mcl_colorblocks:concrete_white"
+	steel_ingot = "mcl_core:iron_ingot"
+	cobble = "mcl_core:cobble"
+	base_ingredient = "mcl_core:copper"
+end
+-- We still want to use concrete specifically if we have mcl_core
+if has_mcl_core then
+	dye_red = "mcl_colorblocks:concrete_red"
+	dye_white = "mcl_colorblocks:concrete_white"
+end
 
 local function register_recipe(nname,nnum,count,_type)
-	local this_recipe = {"dye:white"}
+	local this_recipe = {dye_white}
 	-- add red color
 	if nname == "koncovnik_" or nname == "nameznik_konc_" or nname == "koncovnik_konc_" then
-		table.insert(this_recipe,"dye:red")
+		table.insert(this_recipe,dye_red)
 	end
 	if nname == "koncovnik_" then
-		table.insert(this_recipe,"default:steel_ingot")
+		table.insert(this_recipe,steel_ingot)
 	end
 	if nname == "hranicnik" then
-		table.insert(this_recipe,"default:cobble")
+		table.insert(this_recipe,cobble)
 	end
 	if recipes_table[_type] ~= nil then
 		table.insert(this_recipe, recipes_table[_type])
@@ -72,7 +105,7 @@ local function register_recipe(nname,nnum,count,_type)
 	local x = tonumber(nnum)
 	if x == nil then x = 0 end
 	for _ = 1, x do
-		table.insert(this_recipe,"default:tin_ingot")
+		table.insert(this_recipe,base_ingredient)
 	end
 	_type = _type:sub(2)
 	--if _type ~= nil and _type ~= "" then _type = _type .. "_" end

--- a/nameznik.lua
+++ b/nameznik.lua
@@ -29,12 +29,62 @@ local nameznik__nodebox_r1h = {type = "fixed",fixed = {
 local nameznik__sboxr = {type = "fixed",fixed = {
             {-0.5, -0.5, -0.1, 1, -0.35, 0.1}}}
 
+local function get_palette(nname)
+	if nname == "nameznik_" or nname == "nameznik_konc_" or nname == "koncovnik_" then
+		return "nameznik_palette1.png"
+	elseif nname == "hranicnik" then
+		return "nameznik_palette2.png"
+	end
+	--safety
+	core.log("warning","Nameznik: cannot get palette choice for " .. nnname)
+	return "nameznik_palette1.png"
+end
+
+-- default ingredients
+local recipes_table = {
+	-- empty simply is left undefined, so nothing is added
+	_r05_ = "default:gravel",
+	_r1_ = "default:sand",
+	_r05h_ = "default:sandstone",
+	_r1h_ = "default:flint"
+}
+local dye_red = "dye:red"
+local dye_white = "dye:white"
+local steel_ingot = "default:steel_ingot"
+local cobble = "default:cobble"
+local base_ingredient = "default:tin_ingot"
+
+local function register_recipe(nname,nnum,count,_type)
+	local this_recipe = {"dye:white"}
+	-- add red color
+	if nname == "koncovnik_" or nname == "nameznik_konc_" or nname == "koncovnik_konc_" then
+		table.insert(this_recipe,"dye:red")
+	end
+	if nname == "koncovnik_" then
+		table.insert(this_recipe,"default:steel_ingot")
+	end
+	if nname == "hranicnik" then
+		table.insert(this_recipe,"default:cobble")
+	end
+	if recipes_table[_type] ~= nil then
+		table.insert(this_recipe, recipes_table[_type])
+	end
+	local x = tonumber(nnum)
+	if x == nil then x = 0 end
+	for _ = 1, x do
+		table.insert(this_recipe,"default:tin_ingot")
+	end
+	_type = _type:sub(2)
+	--if _type ~= nil and _type ~= "" then _type = _type .. "_" end
+	minetest.register_craft({
+		output = "nameznik:" .. _type .. nname .. nnum .. " " .. count,
+		type = "shapeless",
+		recipe = this_recipe
+	})
+end
+
 local function nameznik_regnode(nname, nnum, ndesc, nfront, nside, nback)
-	local npalette
-	if nname == "nameznik_" then npalette = "nameznik_palette1.png" end
-	if nname == "nameznik_konc_" then npalette = "nameznik_palette1.png" end
-	if nname == "koncovnik_" then npalette = "nameznik_palette1.png" end
-	if nname == "hranicnik" then npalette = "nameznik_palette2.png" end
+	local npalette = get_palette(nname)
 
 	minetest.register_node("nameznik:" .. nname .. nnum, {
 		description = S(ndesc) .. " " .. nnum,
@@ -55,14 +105,11 @@ local function nameznik_regnode(nname, nnum, ndesc, nfront, nside, nback)
 		is_ground_content = false,
 		palette = npalette,
 	})
+	register_recipe(nname, nnum, 15, "")
 end
 
 local function nameznik_regnoder05(nname, nnum, ndesc, nfront, nside, nback)
-	local npalette
-	if nname == "nameznik_" then npalette = "nameznik_palette1.png" end
-	if nname == "nameznik_konc_" then npalette = "nameznik_palette1.png" end
-	if nname == "koncovnik_" then npalette = "nameznik_palette1.png" end
-	if nname == "hranicnik" then npalette = "nameznik_palette2.png" end
+	local npalette = get_palette(nname)
 
 	minetest.register_node("nameznik:r05_" .. nname .. nnum, {
 		description = S(ndesc) .. " "..S("right").." +0,5 " .. nnum,
@@ -84,11 +131,11 @@ local function nameznik_regnoder05(nname, nnum, ndesc, nfront, nside, nback)
 		is_ground_content = false,
 		palette = npalette,
 	})
+	register_recipe(nname, nnum, 15, "_r05_")
 end
 
 local function nameznik_regnoder1(nname, nnum, ndesc, nfront, nside, nback)
-	local npalette
-	if nname == "hranicnik" then npalette = "nameznik_palette2.png" end
+	local npalette = get_palette(nname)
 
 	minetest.register_node("nameznik:r1_" .. nname .. nnum, {
 		description = S(ndesc) .. " "..S("right").." +1 ".. nnum,
@@ -110,11 +157,11 @@ local function nameznik_regnoder1(nname, nnum, ndesc, nfront, nside, nback)
 		is_ground_content = false,
 		palette = npalette,
 	})
+	register_recipe(nname, nnum, 15, "_r1_")
 end
 
 local function nameznik_regnoder05h(nname, nnum, ndesc, nfront, nside, nback)
-	local npalette
-	if nname == "hranicnik" then npalette = "nameznik_palette2.png" end
+	local npalette = get_palette(nname)
 
 	minetest.register_node("nameznik:r05h_" .. nname .. nnum, {
 		description = S(ndesc) .. " "..S("right").." +0,5 "..S("higher").." " .. nnum,
@@ -136,11 +183,11 @@ local function nameznik_regnoder05h(nname, nnum, ndesc, nfront, nside, nback)
 		is_ground_content = false,
 		palette = npalette,
 	})
+	register_recipe(nname, nnum, 15, "_r05h_")
 end
 
 local function nameznik_regnoder1h(nname, nnum, ndesc, nfront, nside, nback)
-	local npalette
-	if nname == "hranicnik" then npalette = "nameznik_palette2.png" end
+	local npalette = get_palette(nname)
 
 	minetest.register_node("nameznik:r1h_" .. nname .. nnum, {
 		description = S(ndesc) .. " "..S("right").." +1 "..S("higher").." " .. nnum,
@@ -162,6 +209,7 @@ local function nameznik_regnoder1h(nname, nnum, ndesc, nfront, nside, nback)
 		is_ground_content = false,
 		palette = npalette,
 	})
+	register_recipe(nname, nnum, 15, "_r1h_")
 end
 
 nameznik_regnode("nameznik_","1","Fouling point marker","nameznik_over1.png","","nameznik_over1.png")


### PR DESCRIPTION
As discussed in the [forum thread](https://forum.luanti.org/viewtopic.php?t=31792&sid=a6c568dc972445571db53c4ee62c7386). I hope shapeless recipes are acceptable to you.

I chose copper as a base ingredient, and various generic blocks for making the distinctions between the rotation/placement types. I wasn't sure how to get a single shapeless recipe to map to various things, since there's not really supposed to be a difference between the objects.

If you like the ingredients but think I should put thought into a shaped recipe for each one, let me know and I could try to devise something for that.